### PR TITLE
AWS XEN upgrade update

### DIFF
--- a/reference-new.adoc
+++ b/reference-new.adoc
@@ -124,8 +124,11 @@ TIP: Automatic upgrades of the Connector are enabled by default so you should be
 
 * Upgrading an HA pair is nondisruptive and I/O is uninterrupted. During this nondisruptive upgrade process, each node is upgraded in tandem to continue serving I/O to clients.
 
-=== c4, m4, and r4 instance types
+=== Upgrades in AWS with c4, m4, and r4 EC2 instance types
 
-Starting with the 9.8 release, c4, m4, and r4 instance types aren't supported with new Cloud Volumes ONTAP systems. If you have an existing Cloud Volumes ONTAP system that's running on a c4, m4, or r4 instance type, you can still upgrade to this release.
+In AWS, the c4, m4, and r4 EC2 instance types are no longer supported with new Cloud Volumes ONTAP deployments. If you have an existing system that's running on a c4, m4, or r4 instance type, you must change to an instance type in the c5, m5, or r5 instance family. If you can't change the instance type, you need to enable enhanced networking before upgrading. 
 
-We recommend changing to an instance type in the c5, m5, or r5 instance family.
+link:https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-updating-ontap-cloud.html#upgrades-in-aws-with-c4-m4-and-r4-ec2-instance-types[Learn how to upgrade in AWS with c4, m4, and r4 EC2 instance types^].
+link:https://docs.netapp.com/us-en/bluexp-cloud-volumes-ontap/task-change-ec2-instance.html[Learn how to change the EC2 instance type for Cloud Volumes ONTAP^].
+
+Refer to link:https://mysupport.netapp.com/info/communications/ECMLP2880231.html[NetApp Support^] to learn more about the end of availability and support for these instance types. 


### PR DESCRIPTION
Includes the following changes:

- Moves information about upgrades with AWS c4, m4, and r4 instances to Upgrade notes on the What's new page
- Provides a reference to the Upgrade Cloud Volumes ONTAP page with details about upgrades with AWS c4, m4, and r4 instances

https://github.com/NetAppDocs/cloud-volumes-ontap-relnotes/issues/64